### PR TITLE
Remove twitter icon from footer

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -199,7 +199,6 @@
 																		<td align="center">
 																			<table border="0" cellspacing="0" cellpadding="0">
 																				<tr>
-																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://twitter.com/rubygems_status" target="_blank" rel="noopener"><img src="<%= image_url("twitter_mail_icon.png") %>" border="0" width="34" height="34" alt="" /></a></td>
 																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://github.com/rubygems" target="_blank" rel="noopener"><img src="<%= image_url("github_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
 																					<td class="img-center" style="font-size:0pt; line-height:0pt; text-align:center" width="38"><a href="https://groups.google.com/forum/#!forum/rubygems-org" target="_blank" rel="noopener"><img src="<%= image_url("google_group_icon.png") %>" border="0" width="28" height="28" alt="" /></a></td>
 																				</tr>


### PR DESCRIPTION
Bug: https://github.com/rubygems/rubygems.org/issues/4600 

Goal: Remove twitter icon from footer 

Before: 
![image](https://github.com/jacklynhma/rubygems.org/assets/29336370/6261bf3e-041e-49a0-9f61-7b0c667f4e41)

After: 
Computer view: 
<img width="782" alt="Screenshot 2024-05-08 at 4 00 50 PM" src="https://github.com/jacklynhma/rubygems.org/assets/29336370/acc16f08-a62d-421b-8620-cff87cb8a0f4">

Mobile View: 
<img width="519" alt="Screenshot 2024-05-08 at 4 00 46 PM" src="https://github.com/jacklynhma/rubygems.org/assets/29336370/e4a5977d-649b-46e0-b682-ae364ecbda01">
